### PR TITLE
Fix issues with zero durability sieves

### DIFF
--- a/src/main/java/co/q64/exgregilo/link/gregtech/tools/AdvancedMesh.java
+++ b/src/main/java/co/q64/exgregilo/link/gregtech/tools/AdvancedMesh.java
@@ -50,7 +50,7 @@ public class AdvancedMesh extends CustomMetaTool {
 
 	@Override
 	public float getBaseDamage() {
-		return 1.0f;
+		return 10.0f;
 	}
 
 	@Override
@@ -65,7 +65,7 @@ public class AdvancedMesh extends CustomMetaTool {
 
 	@Override
 	public float getMaxDurabilityMultiplier() {
-		return 0.01f;
+		return 0.1f;
 	}
 
 	@Override

--- a/src/main/java/co/q64/exgregilo/link/gregtech/tools/BasicMesh.java
+++ b/src/main/java/co/q64/exgregilo/link/gregtech/tools/BasicMesh.java
@@ -46,7 +46,7 @@ public class BasicMesh extends CustomMetaTool {
 
 	@Override
 	public float getBaseDamage() {
-		return 1.0f;
+		return 10.0f;
 	}
 
 	@Override
@@ -61,7 +61,7 @@ public class BasicMesh extends CustomMetaTool {
 
 	@Override
 	public float getMaxDurabilityMultiplier() {
-		return 0.01f;
+		return 0.1f;
 	}
 
 	@Override

--- a/src/main/java/co/q64/exgregilo/link/gregtech/tools/HeavyMesh.java
+++ b/src/main/java/co/q64/exgregilo/link/gregtech/tools/HeavyMesh.java
@@ -45,7 +45,7 @@ public class HeavyMesh extends CustomMetaTool {
 
 	@Override
 	public float getBaseDamage() {
-		return 1.0f;
+		return 10.0f;
 	}
 
 	@Override
@@ -60,7 +60,7 @@ public class HeavyMesh extends CustomMetaTool {
 
 	@Override
 	public float getMaxDurabilityMultiplier() {
-		return 0.01f;
+		return 0.1f;
 	}
 
 	@Override

--- a/src/main/java/co/q64/exgregilo/tile/AbstractSieveTile.java
+++ b/src/main/java/co/q64/exgregilo/tile/AbstractSieveTile.java
@@ -129,7 +129,7 @@ public abstract class AbstractSieveTile extends TileEntity {
 				if (mesh != null) {
 					if (mesh.getItem() instanceof MetaGeneratedTools) {
 						MetaGeneratedTools tool = (MetaGeneratedTools) mesh.getItem();
-						tool.doDamage(mesh, 1);
+						tool.doDamage(mesh, 10);
 						if (MetaGeneratedTools.getToolMaxDamage(mesh) - MetaGeneratedTools.getToolDamage(mesh) <= 0) {
 							mesh = null;
 							update();


### PR DESCRIPTION
Gregtech uses a long when setting up max durability and a .01 modifier was causing low durability items to come out as decimal only and then getting truncated to 0 when casted to a long. MaxDurabilityModifier has been changed  to .1 instead and damage increased to 10 instead of 1. This way everything has the original intended durability.